### PR TITLE
Identifica estado e validação extra

### DIFF
--- a/zz/zzcpf.sh
+++ b/zz/zzcpf.sh
@@ -1,11 +1,13 @@
 # ----------------------------------------------------------------------------
-# Cria, valida ou formata um número de CPF.
+# Cria, valida, formata ou retorna estado(s) federativo de um número de CPF.
 # Obs.: O CPF informado pode estar formatado (pontos e hífen) ou não.
 # Uso: zzcpf [-f] [cpf]
+#      zzcpf [-estado] [cpf]
 # Ex.: zzcpf 123.456.789-09          # valida o CPF informado
 #      zzcpf 12345678909             # com ou sem pontuação
 #      zzcpf                         # gera um CPF válido (aleatório)
 #      zzcpf -f 12345678909          # formata, adicionando pontuação
+#      zzcpf -estado 12345678909     # retorna estado(s) federativo de um número de CPF
 #
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2004-12-23
@@ -17,10 +19,47 @@ zzcpf ()
 {
 	zzzz -h cpf "$1" && return
 
-	local i n somatoria digito1 digito2 cpf base
+	local i j k n somatoria digito1 digito2 cpf base op etados auxiliar
 
 	# Remove pontuação do CPF informado, deixando apenas números
 	cpf=$(echo "$*" | tr -d -c 0123456789)
+
+	#Retorna estado(s) ao qual o CPF pertence
+	if test "$1" = '-estado'
+	then
+                # Se o CPF estiver vazio, define com zero
+                : ${cpf:=0}
+
+                # Faltou ou sobrou algum número...
+                if test ${#cpf} -ne 11
+                then
+                        zztool erro 'CPF inválido (deve ter 11 dígitos)'
+                        return 1
+                fi
+
+		# Truque para cada dígito da base ser guardado em $1, $2, $3, ...
+	        set - $(echo "$cpf" | sed 's/./& /g')
+
+		#Captura nono digito do CPF
+		op=$9
+
+		#Atribui estado(s) ao qual o CPF pertence
+		case $op in
+		0) estados="Rio Grande do Sul";;
+                1) estados="Distrito Federal, Goiás, Mato Grosso, Mato Grosso do Sul ou Tocantins";;
+                2) estados="Amazonas, Pará, Roraima, Amapá, Acre ou Rondônia";;
+                3) estados="Ceará, Maranhão ou Piauí";;
+                4) estados="Paraíba, Pernambuco, Alagoas ou Rio Grande do Norte";;
+                5) estados="Bahia ou Sergipe";;
+                6) estados="Minas Gerais";;
+                7) estados="Rio de Janeiro ou Espírito Santo";;
+                8) estados="São Paulo";;
+		9) estados="Paraná ou Santa Catarina";;
+		esac
+
+		echo "Local do CPF: $estados"
+		return 0
+	fi
 
 	# Talvez só precisamos formatar e nada mais?
 	if test "$1" = '-f'
@@ -71,6 +110,26 @@ zzcpf ()
 
 		# Apaga os dois últimos dígitos
 		base="${cpf%??}"
+
+		#Inicia um laço para comparar a base com todas as possíveis situações:
+		#De 000.00..-00 até 999.99..-99
+		for ((j=0;j<10;j++))
+	        do
+			#Variável auxiliar para comparação de cada situação
+        	        auxiliar=""
+	                for ((k=0;k<9;k++))
+        	        do
+				#Incrementa os valores da vasriável j até termos 'xxx.xxx.xxx' para a comparação
+                	        auxiliar+="$j"
+	                done
+			#Compara o valor atual da variável auxiliar com a base e, caso seja verdadeiro, retorna o erro
+                	if test "$base" = "$auxiliar"
+	                then
+        	                zztool erro "CPF inválido (não pode conter os 9 primeiros digitos iguais)"
+                	        return 1
+	                fi
+        	done
+		#Fim do laço de verificação de digitos repetidos
 	else
 		# Não foi informado nenhum CPF, vamos gerar um escolhendo
 		# nove dígitos aleatoriamente para formar a base


### PR DESCRIPTION
Inserção de argumento -estado com propósito de identificar os estados federativos do cpf com base no 9º digito do mesmo.
Correção de validação de cpf com todos os dígitos iguais (000.000.000-00,...999.999.999-99).